### PR TITLE
Subscribe to all topics, JS API, and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,11 @@ To test the JS API, a test script is available in the `test` directory. To use i
 python -m http.server
 ```
 Then navigate to `http://[HOST_IP]:8000` in a browser. If running locally, use the IP `localhost`.
+
+## MBot Bridge Protocol
+
+The MBot Bridge server sends and receives JSON messages over websocket. It is primarily intended for *synchronous* data reading, e.g. to read the latest sensor measurement.
+
+**Note:** If you are writing an application where timing is critical or where it is important to never miss a message (e.g. SLAM or a low-level controller), you should use LCM to subscribe to messages directly.
+
+*Documentation coming soon*

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # MBot Bridge
 
-Server and API to bridge mbot functionality with student code.
+Server and API to bridge MBot functionality with student code.
 
 Dependencies:
 * Python 3 (tested on 3.10)
 * LCM 1.4+ (tested on 1.5)
-* MBot messages for Python
+* [MBot messages](https://github.com/mbot-project/mbot_lcm_base) for Python and C++
+
+See the [Documentation](docs/index.md) for more details.
 
 ## Install Instructions
 
@@ -65,11 +67,3 @@ To test the JS API, a test script is available in the `test` directory. To use i
 python -m http.server
 ```
 Then navigate to `http://[HOST_IP]:8000` in a browser. If running locally, use the IP `localhost`.
-
-## MBot Bridge Protocol
-
-The MBot Bridge server sends and receives JSON messages over websocket. It is primarily intended for *synchronous* data reading, e.g. to read the latest sensor measurement.
-
-**Note:** If you are writing an application where timing is critical or where it is important to never miss a message (e.g. SLAM or a low-level controller), you should use LCM to subscribe to messages directly.
-
-*Documentation coming soon*

--- a/README.md
+++ b/README.md
@@ -66,4 +66,4 @@ To test the JS API, a test script is available in the `test` directory. To use i
 ```bash
 python -m http.server
 ```
-Then navigate to `http://[HOST_IP]:8000` in a browser. If running locally, use the IP `localhost`.
+Then navigate to `http://[HOST_IP]:8000/test` in a browser. If running locally, use the IP `localhost`.

--- a/docs/cpp-api.md
+++ b/docs/cpp-api.md
@@ -1,0 +1,3 @@
+# MBot Bridge API: C++
+
+*Coming soon!*

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,78 @@
+# MBot Bridge Documentation
+
+The MBot Bridge is a tool for end-user applications on the MBot without LCM. There are two pieces to the MBot Bridge:
+
+1. The MBot Bridge Server: A process that runs in the background and interfaces with the other MBot programs.
+2. The MBot Bridge API: An API for interfacting with the MBot, available in C++, Python, and Javascript.
+
+The MBot Bridge lets a user read or publish data through websocket requests. Many of the common MBot apps, like the web app or the LCM monitor, rely on the MBot Bridge.
+
+## Quickstart
+
+The MBot Bridge is designed to be easy to use. You can run it (once [installed](../README.md#install-instructions)) with this command:
+```bash
+python -m mbot_bridge.server [--config [PATH/TO/CONFIG]]
+```
+
+**Note:** On many MBots, the MBot Bridge is configured to run on startup. Before running the server, check if it's already running with command `sudo systemctl status mbot-bridge.service`. If it is, skip the above step!
+
+### Python
+
+To use the MBot Bridge API in Python, do:
+```python
+from mbot_bridge.api import MBot
+mbot = MBot()
+```
+You can then use the `mbot` object to send and read messages. This example drives the robot forward for one second:
+```python
+import time
+mbot.drive(0.5, 0, 0)  # Set the robot forward velocity to 0.5 m/s.
+time.sleep(1)          # Sleep for one second.
+mbot.stop()            # Stop the robot.
+```
+You can also read data from the MBot. For example, this code reads the latest odometry data:
+```python
+odom = mbot.read_odometry()  # Returns the odometry in format [x, y, theta].
+```
+
+### C++
+
+To use the MBot Bridge API in C++, do:
+```cpp
+#include <mbot_bridge/robot.h>
+
+int main(int argc, char* argv[])
+{
+    mbot_bridge::MBot mbot;
+}
+```
+You can then use the `mbot` object to read and publish data.
+
+## When to use the MBot Bridge API
+
+The MBot Bridge API is meant to make it easy and quick to program the MBot. It's intended for quick prototyping or beginner programmers.  Use the MBot Bridge API if:
+* You want to write single-threaded code,
+* You don't want to use LCM,
+* You want to read the latest data and don't care about a bit of latency or missed messages.
+
+## When not to use the MBot Bridge API
+
+The MBot Bridge API provides a user-friendly interfact at the cost of some efficiency. In the background, it subscribes to a bunch of LCM channels and stores the data. Then, it waits for websocket requests for the data, formats it, then returns it. For many applications, you probably don't care about a few fractions of a second of delay. For applications where this delay does matter, you can also program the MBot by directly interfacting with the LCM code.
+
+You should choose this option if:
+* You need to write code where it's important to not have delays reading the messages (e.g. SLAM or a low-level controller),
+* You can't miss any messages,
+* You have a time-critical application.
+
+## For developers (Advanced)
+
+A common pattern for tools for the MBot (like visualizers, web apps, or command line utilities) is to aggregate LCM data and then do something with it. If you are building such a tool, you should first check if you can use the MBot Bridge instead of writing your own LCM manager. These types of applications can be expensive, so it's best to use the existing MBot Bridge Server instead of adding a new process that does the same thing.
+
+## API Documentation
+
+The following languages are supported in the current API:
+* [Python](python-api.md)
+* [C++](cpp-api.md)
+* [Javascript](js-api.md)
+
+**Advanced Usage:** You can interface with the MBot Bridge Server directly through websockets (for example, if you want to use it in an unsupported language). See the [server documentation](server.md) for more details.

--- a/docs/js-api.md
+++ b/docs/js-api.md
@@ -1,3 +1,64 @@
 # MBot Bridge API: Javascript
 
-*Coming soon!*
+The Javascript API can be used either with Node.JS or in plain Javascript.
+
+## Installation
+
+### Node.JS (Recommended)
+
+To use the MBot API in a Node project, clone this repo then do:
+```bash
+cd mbot_bridge/mbot_js
+npm install
+npm link
+```
+The command `npm link` makes a symlink of this package available to link in other packages. This is an alternative to registering this package as an official NPM package.
+
+Then, in your own Node project, do:
+```bash
+cd my_project/
+npm link mbot-js-api
+```
+
+To create a MBot object in your project, do:
+```javascript
+import { MBot } from "mbot-js-api";
+
+const mbot = new MBot(mbotIP);
+```
+where `mbotIP` is the IP address of the mbot.
+
+**Tip:** The IP of the robot is often the one you type into the browser to access the web app hosted on the robot. To get this IP, do:
+```javascript
+const mbotIP = window.location.host.split(":")[0]  // Grab the IP from which this page was accessed.
+```
+
+### Plain Javascript
+
+#### Method 1: Use Latest Release (Recommended)
+
+*TODO:* Add instructions to link to the latest release (when it is released).
+
+#### Method 2: Build from source
+
+Use this method if you are developing or if you need the latest (unreleased) version.
+
+First, clone this repo, then do:
+```bash
+cd mbot_bridge/mbot_js
+npm install
+npm run build
+```
+Then include the bundled script `mbot_js/dist/main.js` in your HTML.
+
+To create a MBot object, do:
+```javascript
+const mbot = new MBotAPI.MBot(mbotIP);
+```
+where `mbotIP` is the IP address of the mbot.
+
+## Usage
+
+The Javascript API is based off of [*promises*](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise), which are objects built for handling asynchronous tasks.
+
+*Coming soon*

--- a/docs/js-api.md
+++ b/docs/js-api.md
@@ -59,6 +59,25 @@ where `mbotIP` is the IP address of the mbot.
 
 ## Usage
 
-The Javascript API is based off of [*promises*](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise), which are objects built for handling asynchronous tasks.
+For the full list of available functions, see [robot.js](../mbot_js/src/robot.js). For example usage, see [main.js](../test/main.js).
 
-*Coming soon*
+The Javascript API is based off of [*promises*](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise), which are objects built for handling asynchronous tasks. Except for publishing, all the functions in the `MBot` class use promises. There are two ways to use this:
+
+### Using Promises
+
+You can use the `.then()` and `.catch()` promise attributes. When the promise returns (e.g. when the MBot Bridge server returns the requested data), the function passed to `.then()` will be called with the returned data as the argument. If an error is raised and the promise rejects, the function passed to `.catch()` will be called with the error message. For example, to read the hostname:
+```javascript
+mbot.readHostname().then((hostname) => { console.log("hostname:", hostname); });
+```
+The hostname will be printed once the data is received, which resolves the promise. This does not block the code execution. In this example, we are not catching errors.
+
+### Using `async` / `await`
+You can also use the `async` / `await` syntax, which is essentially a wrapper for promises. For this, you need to be in an `async` function. To read the hostname this way:
+```javascript
+async function readHostname(mbot) {
+    const host = await mbot.readHostname();
+    console.log("Async hostname:", host);
+}
+```
+
+These do the same thing. In general, unless you are already using `async` / `await` in your code, use the promise syntax.

--- a/docs/js-api.md
+++ b/docs/js-api.md
@@ -1,0 +1,3 @@
+# MBot Bridge API: Javascript
+
+*Coming soon!*

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -1,0 +1,3 @@
+# MBot Bridge API: Python
+
+*Coming soon!*

--- a/docs/server.md
+++ b/docs/server.md
@@ -1,0 +1,9 @@
+# The MBot Bridge Server
+
+The MBot Bridge Server must be running in the background in order to use the API. This page describes the configuration and the protocol.
+
+**Note:** This is an advanced guide for developers and instructors. For regular usage, see the [API documentation](index.md#api-documentation).
+
+## Configuration
+
+## MBot Bridge Protocol

--- a/docs/server.md
+++ b/docs/server.md
@@ -7,3 +7,65 @@ The MBot Bridge Server must be running in the background in order to use the API
 ## Configuration
 
 ## MBot Bridge Protocol
+
+The MBot Bridge defines a custom protocol in JSON to communicate over websockets.
+
+**Note:** In most cases, you should use the API rather than creating and sending JSON messages directly. The API provides interfaces for common functionality and constructs JSON messages for you. See the [API documentation](index.md#api-documentation) for more details.
+
+These fields are available for all types:
+* `type`: The message type as an integer (see [Message Types](#message-types))
+
+These types are included in some message types:
+* `channel`: The LCM channel being read or published to
+* `dtype`: The LCM message type being published or requested
+* `as_bytes`: Whether the client wants raw LCM messages in bytes or a formatted string.
+* `data`: A data payload as a string
+
+### Message Types
+
+The following types are defined:
+* `REQUEST`: A request to read data. When a request is sent over a websocket connection, the server will respond with either a `RESPONSE` message or an `ERROR` message on the same websocket connection.
+
+  This message type has the following JSON keys:
+  * `type` (value: `0`): The message type.
+  * `channel`: The LCM channel to read from.
+  * `dtype` (Optional): The LCM message type to read. By default, the server will use its internal knowledge of the data type on the channel in question.
+  * `as_bytes` (Optional. Default: False): If true, the server will return the *raw LCM message*, which is in bytes. The user is then responsible for knowing the LCM type and for decoding it. This is useful for efficiency and for large messages which are inefficient to pass as strings (e.g. large lists of floats). If false, the server will return a `RESPONSE` object with the data as a JSON object.
+
+* `PUBLISH`: A request to publish data. There is no response to this message.
+
+  This message type has the following JSON keys:
+  * `type` (value: `1`): The message type.
+  * `channel`: The LCM channel to publish to.
+  * `dtype`: A string with the name of the LCM message type. The format should be `"my_lcm_type_pkg.my_type_t"`. If the type is in `mbot_lcm_msgs`, the package can be excluded (e.g. `"pose2D_t"`)
+  * `data`: The LCM data to publish formatted as a JSON string.
+
+* `RESPONSE`: A response from the server.
+
+  This message type has the following JSON keys:
+  * `type` (value: `2`): The message type.
+  * `channel`: The LCM channel that was read.
+  * `dtype`: A string with the name of the LCM message type. The format is `"my_lcm_type_pkg.my_type_t"`. If the type is in `mbot_lcm_msgs`, the package can be excluded (e.g. `"pose2D_t"`)
+  * `data`: The data requested formatted as a JSON string.
+
+* `SUBSCRIBE`: A request to subscribe to a certain channel. If the server receives a request to subscribe, it will send *all* data on the given channel back along the same websocket connection, until the connection is closed or an `UNSUBSCRIBE` message is sent.
+
+  *Note:* This is mostly useful for languages that are not supported by LCM (e.g. Javascript). Subscribe functionality is not supported by the Python or C++ APIs. If using these languages, you should subscribe with LCM if you need this functionality.
+
+  This message type has the following JSON keys:
+  * `type` (value: `3`): The message type.
+  * `channel`: The LCM channel to subscribe to.
+  * `dtype` (Optional): The LCM message type to read. By default, the server will use its internal knowledge of the data type on the channel in question.
+  * `as_bytes` (Optional. Default: False): If true, the server will return the *raw LCM message*, which is in bytes. The user is then responsible for knowing the LCM type and for decoding it. This is useful for efficiency and for large messages which are inefficient to pass as strings (e.g. large lists of floats). If false, the server will return a `RESPONSE` object with the data as a JSON object.
+
+* `UNSUBSCRIBE`: A request to unsubscribe from a channel on the given websocket connection.
+
+  This message type has the following JSON keys:
+  * `type` (value: `4`): The message type.
+  * `channel`: The LCM channel to unsubscribe from.
+
+* `ERROR`: An error response from the server.
+
+  This message type has the following JSON keys:
+  * `type` (value: `-98`): The message type.
+  * `data`: A string with the error message from the server.

--- a/mbot_cpp/include/mbot_bridge/comms.h
+++ b/mbot_cpp/include/mbot_bridge/comms.h
@@ -108,9 +108,12 @@ template <class T>
 class MBotBridgeReader : public MBotWSCommBase
 {
 public:
-    MBotBridgeReader(const std::string& ch, const std::string& uri = "ws://localhost:5005") :
+    MBotBridgeReader(const std::string& ch,
+                     const std::string& uri = "ws://localhost:5005",
+                     const bool as_bytes = true) :
         MBotWSCommBase(uri),
-        channel_(ch)
+        channel_(ch),
+        as_bytes_(as_bytes)
     {
         // Register the open handler.
         c_.set_open_handler(websocketpp::lib::bind(&MBotBridgeReader::on_open, this, ::_1));
@@ -132,11 +135,12 @@ public:
 private:
     std::string channel_;
     MBotMessageType res_type_;  // Response type, to check for errors.
+    bool as_bytes_;             // Whether to request the data as raw bytes.
     T data_;
 
     void on_open(websocketpp::connection_hdl hdl){
         // Request the data.
-        MBotJSONMessage msg("", channel_, "", MBotMessageType::REQUEST);
+        MBotJSONMessage msg("", channel_, "", MBotMessageType::REQUEST, as_bytes_);
         c_.send(hdl, msg.encode(), websocketpp::frame::opcode::text);
     }
 

--- a/mbot_cpp/include/mbot_bridge/mbot_json_msgs.h
+++ b/mbot_cpp/include/mbot_bridge/mbot_json_msgs.h
@@ -30,14 +30,18 @@ public:
         data_(""),
         channel_(""),
         dtype_(""),
-        rtype_(MBotMessageType::INVALID)
+        rtype_(MBotMessageType::INVALID),
+        as_bytes_(false)
     {};
 
-    MBotJSONMessage(const std::string& data, const std::string& ch, const std::string& dtype, const MBotMessageType& rtype) :
+    MBotJSONMessage(const std::string& data, const std::string& ch,
+                    const std::string& dtype, const MBotMessageType& rtype,
+                    const bool as_bytes = false) :
         data_(data),
         channel_(ch),
         dtype_(dtype),
-        rtype_(rtype)
+        rtype_(rtype),
+        as_bytes_(as_bytes)
     {};
 
     std::string encode() const
@@ -58,6 +62,11 @@ public:
         if (data_.length() > 0)
         {
             oss << "," << "\"data\":{" << data_ << "}";
+        }
+        if (rtype_ == MBotMessageType::REQUEST)
+        {
+            // If we are requesting data, include whether or not it should be in byte form.
+            oss << "," << keyValToJSON("as_bytes", as_bytes_);
         }
         oss << "}";  // Close msg.
 
@@ -110,6 +119,7 @@ private:
     std::string channel_;
     std::string dtype_;
     MBotMessageType rtype_;
+    bool as_bytes_;
 
     std::string typeToString(const MBotMessageType& t) const
     {

--- a/mbot_js/package.json
+++ b/mbot_js/package.json
@@ -2,6 +2,7 @@
   "name": "mbot-js-api",
   "version": "0.0.1",
   "description": "A Javascript API for the MBot",
+  "main": "/src/robot.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "webpack"

--- a/mbot_js/src/robot.js
+++ b/mbot_js/src/robot.js
@@ -143,17 +143,18 @@ class MBot {
     this._publish(data, config.MOTOR_VEL_CMD.channel, config.MOTOR_VEL_CMD.dtype)
   }
 
-  async readOdometry(odomCallback) {
-    let waitForData = this._read(config.ODOMETRY.channel);
-    waitForData.then((val) => {
-      let odom = [];
-      if (val.rtype === MBotMessageType.RESPONSE) {
-        odom = [val.data.x, val.data.y, val.data.theta];
-      }
-      odomCallback(odom);
+  readOdometry() {
+    let promise = new Promise((resolve, reject) => {
+      this._read(config.ODOMETRY.channel).then((val) => {
+        const odom = [val.data.x, val.data.y, val.data.theta];
+        resolve(odom)
+      }).catch((error) => {
+        reject(error)
+      });
     });
-    await waitForData;
+
+    return promise;
   }
 }
 
-export { MBot };
+export { MBot, config };

--- a/mbot_js/src/robot.js
+++ b/mbot_js/src/robot.js
@@ -73,6 +73,38 @@ class MBot {
     this.ws_subs[ch] = null;
   }
 
+  async readHostname(cb) {
+    // Reads the hostname.
+    let waitForData = this._read("HOSTNAME");
+    waitForData.then((val) => {
+      let hostname = "";
+      if (val.rtype === MBotMessageType.RESPONSE) {
+        hostname = val.data;
+      }
+      else {
+        console.warn("Bad response:", val);
+      }
+      cb(hostname);
+    });
+    await waitForData;
+  }
+
+  async readChannels(cb) {
+    // Gets the list of all channels subscribed to.
+    let waitForData = this._read("CHANNELS");
+    waitForData.then((val) => {
+      let channels = [];
+      if (val.rtype === MBotMessageType.RESPONSE) {
+        channels = val.data;
+      }
+      else {
+        console.warn("Bad response:", val);
+      }
+      cb(channels);
+    });
+    await waitForData;
+  }
+
   drive(vx, vy, wz) {
     let data = { "vx": vx, "vy": vy, "wz": wz };
     this._publish(data, config.MOTOR_VEL_CMD.channel, config.MOTOR_VEL_CMD.dtype)

--- a/src/mbot_bridge/config/default.yml
+++ b/src/mbot_bridge/config/default.yml
@@ -1,17 +1,23 @@
 lcm_address: "udpm://239.255.76.67:7667?ttl=1"
-# The server listens to these channels.
-subs:
-  - channel: "LIDAR"
-    type: "lidar_t"
-  - channel: "MBOT_ODOMETRY"
-    type: "pose2D_t"
-  - channel: "SLAM_POSE"
-    type: "pose2D_t"
-# The server publishes messages to these channels.
-pubs:
-  - channel: "MBOT_VEL_CMD"
-    type: "twist2d_t"
-  - channel: "MBOT_ODOMETRY_RESET"
-    type: "pose2D_t"
-  - channel: "CONTROLLER_PATH"
-    type: "path2D_t"
+# Configure which channels to listen to. This must be either the string "all",
+# to subscribe to all the available LCM channels, or a list of the channels to
+# subscribe to. The list should contain dictionaries with two keys: "channel",
+# with the channel name, and "type", with the type name. For example:
+#   subs:
+#     - channel: "LIDAR"
+#       type: "lidar_t"
+#     - channel: "SLAM_POSE"
+#       type: "pose2D_t"
+# The "type" can be any type that can be imported by the bridge, written in the
+# form "my_custom_pkg.my_type_t". If no module is specified, the bridge will
+# attempt to load the type from the package "mbot_lcm_msgs".
+subs: "all"
+# A list of strings with channel names to ignore.
+ignore_channels: []
+# A list of strings with the names of Python packages to search for LCM types.
+# The bridge will look here to try to determine the type of a message if it was
+# not provided. These must be importable by the bridge.
+lcm_type_modules:
+  - mbot_lcm_msgs
+# The map channel, for efficiency considerations.
+map_channel: SLAM_MAP

--- a/src/mbot_bridge/server.py
+++ b/src/mbot_bridge/server.py
@@ -58,6 +58,11 @@ class LCMMessageQueue(object):
     def empty(self):
         return len(self._queue) == 0
 
+    def header(self):
+        return {"channel": self.channel,
+                "dtype": self.dtype,
+                "queue_size": self.queue_size}
+
 
 class MBotBridgeServer(object):
     def __init__(self, lcm_address, subs, ignore_channels=[],
@@ -239,6 +244,11 @@ class MBotBridgeServer(object):
         if ch == "HOSTNAME":
             # If hostname, return the hostname as a string.
             res = MBotJSONResponse(self._hostname, ch, "")
+            return res
+        elif ch == "CHANNELS":
+            # If channels, return the list of current subscriptions.
+            subs = [v.header() for _, v in self._msg_managers.items()]
+            res = MBotJSONResponse(subs, ch, "")
             return res
         elif ch not in self._msg_managers:
             # If the channel being requested does not exist, return an error.

--- a/src/mbot_bridge/utils/json_messages.py
+++ b/src/mbot_bridge/utils/json_messages.py
@@ -18,7 +18,7 @@ class BadMBotRequestError(Exception):
 
 
 class MBotJSONMessage(object):
-    def __init__(self, data=None, channel=None, dtype=None, rtype=None, from_json=False):
+    def __init__(self, data=None, channel=None, dtype=None, rtype=None, as_bytes=False, from_json=False):
         if from_json:
             self.decode(data)
         else:
@@ -31,6 +31,7 @@ class MBotJSONMessage(object):
             self._data = data
             self._channel = channel
             self._dtype = dtype
+            self._as_bytes = as_bytes
 
     def data(self):
         return self._data
@@ -43,6 +44,9 @@ class MBotJSONMessage(object):
 
     def channel(self):
         return self._channel
+
+    def as_bytes(self):
+        return self._as_bytes
 
     def encode(self):
         if self._request_type == MBotMessageType.INIT:
@@ -68,6 +72,8 @@ class MBotJSONMessage(object):
             msg.update({"channel": self._channel})
         if self._dtype is not None:
             msg.update({"dtype": self._dtype})
+        if self._request_type in [MBotMessageType.REQUEST, MBotMessageType.SUBSCRIBE]:
+            msg.update({"as_bytes": self._as_bytes})
         if self._data is not None:
             # Special consideration for the lidar data because it's so big.
             if self._dtype == "lidar_t":
@@ -122,6 +128,9 @@ class MBotJSONMessage(object):
         if "dtype" in data:
             dtype = data["dtype"]
 
+        # Whether the data should be returned in raw bytes.
+        as_bytes = data["as_bytes"] if "as_bytes" in data else False
+
         # If this was a publish request, data is required.
         if request_type == MBotMessageType.PUBLISH and (msg_data is None or dtype is None):
             raise BadMBotRequestError("Publish was requested but data or data type is missing.")
@@ -130,11 +139,12 @@ class MBotJSONMessage(object):
         self._data = msg_data
         self._dtype = dtype
         self._request_type = request_type
+        self._as_bytes = as_bytes
 
 
 class MBotJSONRequest(MBotJSONMessage):
-    def __init__(self, channel, dtype=None):
-        super().__init__(channel=channel, dtype=dtype, rtype=MBotMessageType.REQUEST)
+    def __init__(self, channel, dtype=None, as_bytes=False):
+        super().__init__(channel=channel, dtype=dtype, as_bytes=as_bytes, rtype=MBotMessageType.REQUEST)
 
 
 class MBotJSONResponse(MBotJSONMessage):

--- a/src/mbot_bridge/utils/type_utils.py
+++ b/src/mbot_bridge/utils/type_utils.py
@@ -57,7 +57,18 @@ def decode(data, dtype):
 
 def lcm_type_to_dict(data):
     """LCM types, once decoded"""
-    data_d = {att: getattr(data, att) for att in data.__slots__}
+    data_d = {}
+    for att, type_name in zip(data.__slots__, data.__typenames__):
+        val = getattr(data, att)
+        if "." in type_name:
+            # This is an LCM type. Decode it first.
+            if isinstance(val, list):
+                # This is a list of types.
+                val = [lcm_type_to_dict(v) for v in val]
+
+            else:
+                val = lcm_type_to_dict(val)
+        data_d.update({att: val})
     return data_d
 
 

--- a/src/mbot_bridge/utils/type_utils.py
+++ b/src/mbot_bridge/utils/type_utils.py
@@ -18,6 +18,34 @@ def str_to_lcm_type(dtype):
     return getattr(mbot_lcm_msgs, dtype)
 
 
+def find_lcm_type(data, pkgs):
+    """Tries to determine the LCM message type of the given data in the list of
+    packages given.
+
+    Args:
+        data: Raw LCM message data to attempt to decode.
+        pkgs: List of strings containing the names of message packages to
+        search in. These must be installed as Python packages in the current
+        environment.
+    """
+    for pkg_name in pkgs:
+        pkg_module = importlib.import_module(pkg_name)
+        for attr in dir(pkg_module):
+            lcm_type_class = getattr(pkg_module, attr)
+            if isinstance(lcm_type_class, type) and hasattr(lcm_type_class, 'decode'):
+                lcm_type = lcm_type_class.__name__
+                try:
+                    # Try to decode the message with this type.
+                    lcm_type_class.decode(data)
+                    # If the decode succeeds, return this as the type.
+                    return lcm_type
+                except ValueError as e:
+                    # If the decode fails, it throws a ValueError and we know this is the wrong type.
+                    continue
+
+    raise BadMessageError(f"Could not parse message type in packages: {[p for p in pkgs]}")
+
+
 def decode(data, dtype):
     """Decode raw data from LCM channel to type based on type string."""
     try:

--- a/test/main.js
+++ b/test/main.js
@@ -2,6 +2,9 @@ window.addEventListener("DOMContentLoaded", () => {
   console.log("Hello!");
   const mbotIP = window.location.host.split(":")[0]  // Grab the IP from which this page was accessed.
   const mbot = new MBotAPI.MBot(mbotIP);
+  mbot.readHostname((hostname) => { console.log("hostname:", hostname); });
+  mbot.readChannels((chs) => { console.log("chs:", chs); });
+
   mbot.drive(0, 0, 0);
   mbot.readOdometry((odom) => { console.log("Odom:", odom); });
 

--- a/test/main.js
+++ b/test/main.js
@@ -2,8 +2,8 @@ window.addEventListener("DOMContentLoaded", () => {
   console.log("Hello!");
   const mbotIP = window.location.host.split(":")[0]  // Grab the IP from which this page was accessed.
   const mbot = new MBotAPI.MBot(mbotIP);
-  mbot.readHostname((hostname) => { console.log("hostname:", hostname); });
-  mbot.readChannels((chs) => { console.log("chs:", chs); });
+  mbot.readHostname().then((hostname) => { console.log("hostname:", hostname); });
+  mbot.readChannels().then((chs) => { console.log("chs:", chs); });
 
   mbot.drive(0, 0, 0);
   mbot.readOdometry((odom) => { console.log("Odom:", odom); });

--- a/test/main.js
+++ b/test/main.js
@@ -6,16 +6,16 @@ window.addEventListener("DOMContentLoaded", () => {
   mbot.readChannels().then((chs) => { console.log("chs:", chs); });
 
   mbot.drive(0, 0, 0);
-  mbot.readOdometry((odom) => { console.log("Odom:", odom); });
+  mbot.readOdometry().then((odom) => { console.log("Odom:", odom); });
 
   let sub = false;
   document.getElementById('subscribeButton').addEventListener('click', function () {
     if (!sub) {
-      mbot.subscribe(config.ODOMETRY.channel, (odom) => { console.log("SUB:", odom); });
+      mbot.subscribe(MBotAPI.config.ODOMETRY.channel, (odom) => { console.log("SUB:", odom); });
       sub = true;
     }
     else {
-      mbot.unsubscribe(config.ODOMETRY.channel);
+      mbot.unsubscribe(MBotAPI.config.ODOMETRY.channel);
       sub = false;
     }
   });


### PR DESCRIPTION
This PR adds a few things:

### Subscribe to all channels 

The ability for the server to subscribe to all the channels instead of just the ones specified. This is now the default behaviour. 

This allows us to write more useful tools for visualizing and debugging. The old way still works, and will be more efficient if computation is a concern and you don't want to use visualization tools.

Fixes #19 

### JS API

Adds official support for using the MBot Bridge API in Javascript. This will be useful for developing web apps.

Fixes #20 

### Documentation

Documentation is started (but not completed) in the `docs` folder. This will eventually live on the MBot website central documentation.