### PR TITLE
Support the use of custom messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ python -m mbot_bridge.server [--config [PATH/TO/CONFIG]]
 ```
 The `--config` argument is optional and will default to `src/mbot_bridge/config/default.yml`.
 
+Do `python -m mbot_bridge.server -h` for a full list of options.
+
 **Import errors in your virtual environment?** If you get import errors (e.g. for NumPy and LCM) you need to share the system packages with the virtual environment. If you are using `venv`, you can do this with:
 ```bash
 python3 -m venv --system-site-packages ~/.envs/my-mbot-env

--- a/mbot_cpp/include/mbot_bridge/comms.h
+++ b/mbot_cpp/include/mbot_bridge/comms.h
@@ -113,21 +113,6 @@ public:
                      const bool as_bytes = true) :
         MBotWSCommBase(uri),
         channel_(ch),
-        as_bytes_(as_bytes),
-        decoder_(DefaultDataToLCMDecoder())
-    {
-        // Register the open handler.
-        c_.set_open_handler(websocketpp::lib::bind(&MBotBridgeReader::on_open, this, ::_1));
-        c_.set_message_handler(websocketpp::lib::bind(&MBotBridgeReader::on_message, this, ::_1, ::_2));
-    };
-
-    MBotBridgeReader(const std::string& ch,
-                     const DataToLCMDecoder& decoder,
-                     const std::string& uri = "ws://localhost:5005",
-                     const bool as_bytes = true) :
-        MBotWSCommBase(uri),
-        channel_(ch),
-        decoder_(decoder),
         as_bytes_(as_bytes)
     {
         // Register the open handler.
@@ -154,7 +139,6 @@ private:
     MBotMessageType res_type_;  // Response type, to check for errors.
     bool as_bytes_;             // Whether to request the data as raw bytes.
     T data_;
-    DataToLCMDecoder decoder_;  // Decoder class.
 
     void on_open(websocketpp::connection_hdl hdl){
         // Request the data.
@@ -171,7 +155,7 @@ private:
 
             if (res_type_ == MBotMessageType::RESPONSE)
             {
-                decoder_.decode(in_msg.data(), data_);
+                stringToLCMType(in_msg.data(), data_);
             }
             else if (res_type_ == MBotMessageType::ERROR)
             {

--- a/mbot_cpp/include/mbot_bridge/json_utils.h
+++ b/mbot_cpp/include/mbot_bridge/json_utils.h
@@ -9,6 +9,7 @@
 #include <fstream>
 #include <regex>
 
+namespace mbot_bridge {
 
 static inline std::string strip(const std::string& s)
 {
@@ -226,5 +227,7 @@ static inline std::map<std::string, std::string> jsonToMap(const std::string& in
 
     return data;
 }
+
+}   // namespace mbot_bridge
 
 #endif // MBOT_BRIDGE_JSON_HELPERS_H

--- a/mbot_cpp/include/mbot_bridge/lcm_utils.h
+++ b/mbot_cpp/include/mbot_bridge/lcm_utils.h
@@ -24,6 +24,7 @@
 #define CONTROLLER_PATH_CHANNEL "CONTROLLER_PATH"
 #define CONTROLLER_PATH_TYPE "path2D_t"
 
+namespace mbot_bridge {
 
 static inline std::string lcmTypeToString(const mbot_lcm_msgs::twist2D_t& data)
 {
@@ -126,5 +127,36 @@ static inline void stringToLCMType(const std::string& data, mbot_lcm_msgs::lidar
     }
 }
 
+
+class DataToLCMDecoder {
+public:
+    DataToLCMDecoder()
+    {};
+
+    template <class T>
+    void decode(const std::string& data, T& out) {
+        // This base function does nothing and should be overridden.
+    };
+};
+
+
+class DefaultDataToLCMDecoder : public DataToLCMDecoder {
+public:
+    DefaultDataToLCMDecoder() :
+        DataToLCMDecoder()
+    {};
+
+    /**
+     * This default string data to LCM message type converter attempts to use an
+     * existing stringToLCMType function. This will fail to compile if used with
+     * an unknown type.
+     */
+    template <class T>
+    void decode(const std::string& data, T& out) {
+        stringToLCMType(data, out);
+    };
+};
+
+}   // namespace mbot_bridge
 
 #endif // MBOT_BRIDGE_LCM_UTILS_H

--- a/mbot_cpp/include/mbot_bridge/lcm_utils.h
+++ b/mbot_cpp/include/mbot_bridge/lcm_utils.h
@@ -127,36 +127,6 @@ static inline void stringToLCMType(const std::string& data, mbot_lcm_msgs::lidar
     }
 }
 
-
-class DataToLCMDecoder {
-public:
-    DataToLCMDecoder()
-    {};
-
-    template <class T>
-    void decode(const std::string& data, T& out) {
-        // This base function does nothing and should be overridden.
-    };
-};
-
-
-class DefaultDataToLCMDecoder : public DataToLCMDecoder {
-public:
-    DefaultDataToLCMDecoder() :
-        DataToLCMDecoder()
-    {};
-
-    /**
-     * This default string data to LCM message type converter attempts to use an
-     * existing stringToLCMType function. This will fail to compile if used with
-     * an unknown type.
-     */
-    template <class T>
-    void decode(const std::string& data, T& out) {
-        stringToLCMType(data, out);
-    };
-};
-
 }   // namespace mbot_bridge
 
 #endif // MBOT_BRIDGE_LCM_UTILS_H

--- a/src/mbot_bridge/api/mbot.py
+++ b/src/mbot_bridge/api/mbot.py
@@ -44,8 +44,22 @@ class MBot(object):
 
     """SUBSCRIBERS"""
 
-    async def _request(self, ch, dtype=None, as_bytes=False):
-        res = MBotJSONRequest(ch, dtype=dtype, as_bytes=as_bytes)
+    async def _request(self, ch, dtype=None, as_bytes=False, request_as_bytes=False):
+        """Internal wrapper to request data from the MBot Bridge Server.
+
+        Args:
+            ch (str): The channel to request data from.
+            dtype (str, optional): The LCM data type to expect from the data. Must be provided if as_bytes is False.
+                                   Defaults to None.
+            as_bytes (bool, optional): Whether to return the data as bytes. Defaults to False.
+            request_as_bytes (bool, optional): Whether to request the data to be sent as bytes. Defaults to True.
+
+        Returns:
+            (bytes or obj): The data returned by the server. If as_bytes is False, the data is returned as an
+                            LCM message type. If True, the data is returned in raw bytes. Returns None if fetching the
+                            data fails.
+        """
+        res = MBotJSONRequest(ch, dtype=dtype, as_bytes=request_as_bytes)
         try:
             async with websockets.connect(self.uri, open_timeout=self.connect_timeout) as websocket:
                 await websocket.send(res.encode())
@@ -56,8 +70,15 @@ class MBot(object):
             print(f"[MBot API] ERROR: Cannot connect to MBot Bridge at: {self.uri}")
             return
 
+        # If the data was requested as bytes and returned as bytes, return the raw data.
+        if isinstance(response, bytes) and as_bytes:
+            return response
+
+        # If the data was not requested as bytes, try to decode it.
         if isinstance(response, bytes):
-            assert dtype is not None, "Must provide data type to process data as bytes."
+            if dtype is None:
+                print("[MBot API] ERROR: Must provide data type to process data as bytes.")
+                return
             try:
                 msg = type_utils.decode(response, dtype)
             except type_utils.BadMessageError as e:
@@ -65,7 +86,8 @@ class MBot(object):
                 return
 
             return msg
-        # Convert this to a JSON message.
+
+        # If this was not bytes, process the JSON message.
         response = MBotJSONMessage(response, from_json=True)
 
         # Check if this is an error. If so, print it and quit.
@@ -97,7 +119,7 @@ class MBot(object):
     def read_odometry(self):
         res = asyncio.run(self._request(self.lcm_config.ODOMETRY.channel,
                                         self.lcm_config.ODOMETRY.dtype,
-                                        as_bytes=True))
+                                        as_bytes=False, request_as_bytes=True))
         if res is not None:
             return [res.x, res.y, res.theta]
 
@@ -106,7 +128,7 @@ class MBot(object):
     def read_slam_pose(self):
         res = asyncio.run(self._request(self.lcm_config.SLAM_POSE.channel,
                                         self.lcm_config.SLAM_POSE.dtype,
-                                        as_bytes=True))
+                                        as_bytes=False, request_as_bytes=True))
         if res is not None:
             return [res.x, res.y, res.theta]
 
@@ -115,12 +137,25 @@ class MBot(object):
     def read_lidar(self):
         res = asyncio.run(self._request(self.lcm_config.LIDAR.channel,
                                         self.lcm_config.LIDAR.dtype,
-                                        as_bytes=True))
+                                        as_bytes=False, request_as_bytes=True))
         if res is not None:
             return res.ranges, res.thetas
 
         return [], []
 
-    def read_data(self, channel, dtype):
-        res = asyncio.run(self._request(channel, dtype, as_bytes=True))
+    def read_data(self, channel, dtype=None, as_bytes=False):
+        """Reads the latest data on a given channel and returns it.
+
+        Args:
+            channel (str): The name of the channel to read the data from.
+            dtype (str, optional): The data type of the data on the channel. Required if as_bytes is False. Defaults to None.
+            as_bytes (bool, optional): Whether to return the data as raw bytes. If False, the data will be decoded as
+                                       the dtype. Defaults to False.
+
+        Returns:
+            bytes or obj: The data returned by the server. If as_bytes is False, the data is returned as an
+                          LCM message type. If True, the data is returned in raw bytes. Returns None if fetching the
+                          data fails.
+        """
+        res = asyncio.run(self._request(channel, dtype, as_bytes=as_bytes, request_as_bytes=as_bytes))
         return res

--- a/src/mbot_bridge/config/default.yml
+++ b/src/mbot_bridge/config/default.yml
@@ -1,4 +1,3 @@
-lcm_address: "udpm://239.255.76.67:7667?ttl=1"
 # Configure which channels to listen to. This must be either the string "all",
 # to subscribe to all the available LCM channels, or a list of the channels to
 # subscribe to. The list should contain dictionaries with two keys: "channel",
@@ -12,12 +11,3 @@ lcm_address: "udpm://239.255.76.67:7667?ttl=1"
 # form "my_custom_pkg.my_type_t". If no module is specified, the bridge will
 # attempt to load the type from the package "mbot_lcm_msgs".
 subs: "all"
-# A list of strings with channel names to ignore.
-ignore_channels: []
-# A list of strings with the names of Python packages to search for LCM types.
-# The bridge will look here to try to determine the type of a message if it was
-# not provided. These must be importable by the bridge.
-lcm_type_modules:
-  - mbot_lcm_msgs
-# The map channel, for efficiency considerations.
-map_channel: SLAM_MAP

--- a/src/mbot_bridge/server.py
+++ b/src/mbot_bridge/server.py
@@ -183,7 +183,9 @@ class MBotBridgeServer(object):
             res = MBotJSONResponse(latest, ch, self._msg_managers[ch].dtype)
         except type_utils.BadMessageError as e:
             # If we were asked to decode an unknown type, return an error.
-            res = MBotJSONError(f"Can't decode data on channel {ch} of unknown type.")
+            msg = f"Can't decode data on channel {ch}: {e}"
+            logging.warning(msg)
+            res = MBotJSONError(msg)
         return res
 
     def _init_channel(self, channel, lcm_type=None, data=None):

--- a/src/mbot_bridge/server.py
+++ b/src/mbot_bridge/server.py
@@ -62,15 +62,14 @@ class LCMMessageQueue(object):
         self._lock.release()
 
         # Grab the utime.
-        latest_utime = None
         if self.dtype is not None:
             latest = type_utils.decode(latest, self.dtype)
             if hasattr(latest, "utime"):
-                latest_utime = latest.utime
-        if latest_utime is None:
-            # If the time can't be decoded from the message, use the last push time.
-            utime = int(self._last_push_time * 1e6)
-        return utime
+                return latest.utime
+
+        # If the time can't be decoded from the message, use the last push time.
+        latest_utime = int(self._last_push_time * 1e6)
+        return latest_utime
 
     def pop(self, decode=False):
         first = None

--- a/src/mbot_bridge/server.py
+++ b/src/mbot_bridge/server.py
@@ -181,13 +181,13 @@ class MBotBridgeServer(object):
         # If the user did not specify a channel, try to find it.
         if lcm_type is None:
             if data is None:
-                logging.warn(f"Can't initialize channel without either the type or data: {channel}")
+                logging.warning(f"Can't initialize channel without either the type or data: {channel}")
                 return False
 
             try:
                 lcm_type = type_utils.find_lcm_type(data, self.lcm_type_modules)
             except type_utils.BadMessageError as e:
-                logging.warn(f"Can't find a valid message type for channel: {channel}. Ignoring in future.")
+                logging.warning(f"Can't find a valid message type for channel: {channel}. Ignoring in future.")
                 self._ignore_channels.append(channel)
                 return False
 

--- a/src/mbot_bridge/utils/type_utils.py
+++ b/src/mbot_bridge/utils/type_utils.py
@@ -11,7 +11,8 @@ def str_to_lcm_type(dtype):
     """Accesses the message type by string. Raises AttributeError if the class type is invalid."""
     # Check whether the dtype is a full path to the package.
     if "." in dtype:
-        pkg, msg_type = dtype.split(".")  # The data type should be pkg.msg_type_t.
+        pkg = ".".join(dtype.split(".")[:-1])  # The data type should be pkg.msg_type_t.
+        msg_type = dtype.split(".")[-1]
         pkg = importlib.import_module(pkg)
         return getattr(pkg, msg_type)
 
@@ -38,6 +39,9 @@ def find_lcm_type(data, pkgs):
                 try:
                     # Try to decode the message with this type.
                     lcm_type_class.decode(data)
+                    if pkg_name is not "mbot_lcm_msgs":
+                        # Add the package prefix if this isn't in mbot_lcm_msgs.
+                        lcm_type = pkg_name + "." + lcm_type
                     # If the decode succeeds, return this as the type.
                     return lcm_type
                 except ValueError as e:

--- a/src/mbot_bridge/utils/type_utils.py
+++ b/src/mbot_bridge/utils/type_utils.py
@@ -39,7 +39,7 @@ def find_lcm_type(data, pkgs):
                 try:
                     # Try to decode the message with this type.
                     lcm_type_class.decode(data)
-                    if pkg_name is not "mbot_lcm_msgs":
+                    if pkg_name != "mbot_lcm_msgs":
                         # Add the package prefix if this isn't in mbot_lcm_msgs.
                         lcm_type = pkg_name + "." + lcm_type
                     # If the decode succeeds, return this as the type.


### PR DESCRIPTION
## What's New
These changes are compatible with the new tutorials in the [custom LCM message type tutorial](https://github.com/mbot-project/custom_lcmtype_tutorial).

Summary of changes:
* The server deals with unknown message types by storing them as bytes anyway, and will return unknown messages as bytes if requested. It will return an error if it receives a request to decode an unknown type.
* The Python API allows the user to request custom datatypes data as bytes or JSON.
* ~The C++ API creates a new class, `DataToLCMDecoder `, which a user can extend and implement the function `decode` in order to use the reader class with a custom type.~ Edit: This will be completed in a future PR.
* Many configurations from the config file are moved to arguments to make it easier to change parameters on the fly.